### PR TITLE
Remove unused import that prevents compilation

### DIFF
--- a/protoc-gen-flowtypes/main.go
+++ b/protoc-gen-flowtypes/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway/descriptor"
-	"github.com/pkg/errors"
 	"github.com/tmc/grpcutil/protoc-gen-flowtypes/genflowtypes"
 )
 


### PR DESCRIPTION
protoc-gen-flowtypes currently does not build